### PR TITLE
simple jetstream startup script

### DIFF
--- a/jetstream-setup.sh
+++ b/jetstream-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+
+## add default Jetstream user (uid:1000) to docker group so the user does not
+## have to type `sudo docker` each time.
+## https://www.explainxkcd.com/wiki/index.php/149:_Sandwich
+JETSTREAM_USER=$(getent passwd 1000 | cut -d: -f1)
+adduser $JETSTREAM_USER docker
+
+## automatically install and enable byobu for the default Jetstream user
+apt-get -y install byobu
+sudo -u $JETSTREAM_USER -i /usr/bin/byobu-launcher-install


### PR DESCRIPTION
This simple setup script can be used as a jetstream init script that sets up byobu to start automatically and also allows the main $JETSTREAM_USER to use docker without having to use the sudo command.